### PR TITLE
Include command in error message

### DIFF
--- a/src/stream.js
+++ b/src/stream.js
@@ -75,7 +75,7 @@ exports.createDecodeStream = function (opts) {
         return cb(err)
       }
       if (command.decode.bytes !== message.length) {
-        return cb(new Error('Message length did not match header. ' +
+        return cb(new Error('Message (command ' + message.command + ') length did not match header. ' +
           'In header: ' + message.length + ', read: ' + command.decode.bytes))
       }
 


### PR DESCRIPTION
Had a hard time tracking down messages that lead to errors. This now includes the message command for easier debugging:

<img width="627" alt="screen shot 2017-12-10 at 8 10 08 pm" src="https://user-images.githubusercontent.com/656630/33811897-35b9e348-dde6-11e7-8217-3a362f88dcc9.png">
